### PR TITLE
Fix regex for custom latest scripts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
         "/(^|/)latest\\.[^/]*$/"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)\\s"
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(?:ARG\\s+)?[A-Za-z0-9_]*_VERSION=(?<currentValue>.*)"
       ],
       "versioningTemplate": "docker"
     }


### PR DESCRIPTION
## Summary
- update regex in renovate config so `apps/busycurl/ci/latest.sh` is detected

## Testing
- `task --list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5c78c44832c94db33888fabceeb