### PR TITLE
security: add explicit permissions to CI/CD workflows

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -6,6 +6,9 @@ on:
     branches: ["main"]
     types: ["opened", "synchronize", "reopened"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref }}-pr-validate
   cancel-in-progress: true
@@ -21,7 +24,9 @@ jobs:
     needs: ["simple-checks", "get-changed-images"]
     if: ${{ needs.get-changed-images.outputs.addedOrModified == 'true' }}
     uses: tuxpeople/containers/.github/workflows/build-images.yaml@main
-    secrets: inherit
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     with:
       appsToBuild: "${{ needs.get-changed-images.outputs.addedOrModifiedImages }}"
       pushImages: false

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -1,6 +1,10 @@
 ---
 name: Release on Merge
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: container-release
   cancel-in-progress: false
@@ -27,7 +31,9 @@ jobs:
     needs: ["simple-checks", "get-changed-images"]
     if: ${{ needs.get-changed-images.outputs.addedOrModified == 'true' }}
     uses: tuxpeople/containers/.github/workflows/build-images.yaml@main
-    secrets: inherit
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     with:
       appsToBuild: "${{ needs.get-changed-images.outputs.addedOrModifiedImages }}"
       pushImages: true
@@ -38,4 +44,6 @@ jobs:
     needs: build-images
     if: ${{ always() && needs.build-images.result != 'failure' }}
     uses: ./.github/workflows/render-readme.yaml
-    secrets: inherit
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-scheduled.yaml
+++ b/.github/workflows/release-scheduled.yaml
@@ -1,6 +1,10 @@
 ---
 name: Scheduled Release
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: container-release
   cancel-in-progress: false
@@ -30,10 +34,9 @@ jobs:
     name: Build Images
     needs: simple-checks
     uses: tuxpeople/containers/.github/workflows/build-images.yaml@main
-    secrets: inherit
-    permissions:
-      contents: read
-      packages: write
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     with:
       appsToBuild: ${{ inputs.appsToBuild }}
       force: ${{ inputs.force == true }}
@@ -44,4 +47,6 @@ jobs:
     name: Render Readme
     needs: build-images
     uses: ./.github/workflows/render-readme.yaml
-    secrets: inherit
+    secrets:
+      BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
+      BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -11,6 +11,9 @@ on:
         description: The private key of the GitHub App
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   render-readme:
     name: Render README

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,6 +23,11 @@ on:
     paths:
       - renovate.json
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add explicit permissions to all GitHub Actions workflows
- Replace `secrets: inherit` with specific secret declarations
- Implement principle of least privilege for workflow security

## Security Impact
Previously, workflows had default broad permissions and used `secrets: inherit` which exposes all repository secrets. This PR restricts permissions to minimum required and explicitly declares only needed secrets.

## Changes

### Workflow Permissions Added
- **pr-validate.yaml**: `contents: read` only (no registry access needed)
- **release-on-merge.yaml**: `contents: read`, `packages: write`
- **release-scheduled.yaml**: `contents: read`, `packages: write`  
- **render-readme.yaml**: `contents: write` (for README commits)
- **renovate.yaml**: `contents: read`, `pull-requests: write`, `issues: write`

### Secret Declarations
- Replaced all `secrets: inherit` with explicit declarations:
  - `BOT_APP_ID`
  - `BOT_APP_PRIVATE_KEY`

## Security Benefits
- **Principle of Least Privilege**: Workflows only get permissions they need
- **Secret Exposure Reduction**: Only required secrets are exposed to jobs
- **Attack Surface Minimization**: Compromised workflows have limited capabilities
- **Audit Trail**: Clear visibility of what permissions each workflow uses

## Test Plan
- [ ] Verify all workflows continue to function correctly
- [ ] Test PR validation workflow (should work with read-only permissions)
- [ ] Test release workflows (need package write permissions)
- [ ] Test Renovate workflow (needs PR/issue creation permissions)

🤖 Generated with [Claude Code](https://claude.ai/code)