### PR TITLE
fix: update permissions for release-scheduled workflow

### DIFF
--- a/.github/workflows/release-scheduled.yaml
+++ b/.github/workflows/release-scheduled.yaml
@@ -2,7 +2,7 @@
 name: Scheduled Release
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 concurrency:


### PR DESCRIPTION
Change contents permission from read to write to allow the nested render-readme workflow to commit changes to README.md.

🤖 Generated with [Claude Code](https://claude.ai/code)